### PR TITLE
Add link for Sketch2Code

### DIFF
--- a/Sketch2Code/README.md
+++ b/Sketch2Code/README.md
@@ -1,7 +1,7 @@
 # Sketch2Code Documentation
 
 ## Description
-Sketch2Code is a solution that uses AI to transform a handwritten user interface design from a picture to valid HTML markup code. 
+[Sketch2Code](https://www.ailab.microsoft.com/experiments/30c61484-d081-4072-99d6-e132d362b99d) is a solution that uses AI to transform a handwritten user interface design from a picture to valid HTML markup code. 
 
 ## Process flow
 The process of transformation of a handwritten image to HTML this solution implements is detailed as follows:


### PR DESCRIPTION
Official AI Lab Sketch2Code link was missing from the repository.